### PR TITLE
Fix toast hook listener registration

### DIFF
--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -180,7 +180,7 @@ function useToast() {
         listeners.splice(index, 1)
       }
     }
-  }, [state])
+  }, [])
 
   return {
     ...state,


### PR DESCRIPTION
## Summary
- avoid adding duplicate listeners in `useToast`

## Testing
- `npm run typecheck` *(fails: src/components/techtrack/TechTrackApp.tsx TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_68436d05f160832f95c902265b15494f